### PR TITLE
Fixed off-by-one error in greedy decoder

### DIFF
--- a/test.py
+++ b/test.py
@@ -50,7 +50,7 @@ def greedy_decoder(ctc):
   collapsed = arg_max[repeat_filter]
 
   # discard blank tokens (the blank is always last in the alphabet)
-  blank_filter = np.where(collapsed < (alphabet_size - 1))[0]
+  blank_filter = np.where(collapsed < alphabet_size)[0]
   final_sequence = collapsed[blank_filter]
   full_decode = ''.join([alphabet[letter_idx] for letter_idx in final_sequence])
 


### PR DESCRIPTION
Before this change, the EOS was filtered out using `np.where(collapsed < (alphabet_size - 1))`. This resulted in the line `return full_decode[:full_decode.find('>')]` not being able to find the end of sentence token.